### PR TITLE
Fix WAV normalization edge case and add tests

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1116,6 +1116,7 @@ dependencies = [
  "regex",
  "serde",
  "serde_json",
+ "tempfile",
  "thiserror",
  "whisper-rs",
 ]

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -25,6 +25,9 @@ serde = { version = "1.0", features = ["derive"] }
 serde_json = "1.0"
 clap = { version = "4.5", features = ["derive"] }
 
+[dev-dependencies]
+tempfile = "3.12.0"
+
 [target.'cfg(target_os = "macos")'.dependencies]
 whisper-rs = { version = "0.13.2", features = ["metal"] }
 

--- a/python_tests/test_samples_metadata.py
+++ b/python_tests/test_samples_metadata.py
@@ -1,0 +1,14 @@
+from pathlib import Path
+import wave
+
+
+def test_samples_dots_wav_metadata():
+    project_root = Path(__file__).resolve().parents[1]
+    wav_path = project_root / "samples" / "dots.wav"
+    assert wav_path.exists(), "Expected samples/dots.wav to be present"
+
+    with wave.open(str(wav_path), "rb") as wav_file:
+        assert wav_file.getnchannels() == 1
+        assert wav_file.getframerate() == 16_000
+        assert wav_file.getsampwidth() == 2
+

--- a/src/audio.rs
+++ b/src/audio.rs
@@ -82,9 +82,19 @@ pub fn read_wav_samples(wav_path: &Path) -> Result<Vec<f32>, Box<dyn std::error:
         return Err(format!("Expected Int sample format, found {:?}", spec.sample_format).into());
     }
 
+    let scale = i16::MAX as f32;
+
     let samples: Result<Vec<f32>, _> = reader
         .samples::<i16>()
-        .map(|sample| sample.map(|s| s as f32 / i16::MAX as f32))
+        .map(|sample| {
+            sample.map(|s| {
+                if s == i16::MIN {
+                    -1.0
+                } else {
+                    s as f32 / scale
+                }
+            })
+        })
         .collect();
 
     Ok(samples?)

--- a/tests/audio.rs
+++ b/tests/audio.rs
@@ -1,0 +1,31 @@
+use std::error::Error;
+
+use transcribe_rs::audio::read_wav_samples;
+
+#[test]
+fn read_wav_samples_normalizes_full_range() -> Result<(), Box<dyn Error>> {
+    let temp_dir = tempfile::tempdir()?;
+    let wav_path = temp_dir.path().join("extreme.wav");
+
+    let spec = hound::WavSpec {
+        channels: 1,
+        sample_rate: 16_000,
+        bits_per_sample: 16,
+        sample_format: hound::SampleFormat::Int,
+    };
+
+    {
+        let mut writer = hound::WavWriter::create(&wav_path, spec)?;
+        writer.write_sample(i16::MAX)?;
+        writer.write_sample(i16::MIN)?;
+        writer.finalize()?;
+    }
+
+    let samples = read_wav_samples(&wav_path)?;
+    assert_eq!(samples.len(), 2);
+
+    assert_eq!(samples[0], 1.0);
+    assert_eq!(samples[1], -1.0);
+
+    Ok(())
+}


### PR DESCRIPTION
## Summary
- clamp the minimum 16-bit PCM value during WAV normalization so audio samples stay within [-1.0, 1.0]
- cover the regression with a Rust unit test and add the tempfile dev dependency used to build the fixture
- create a dedicated `python_tests` directory with a metadata smoke test for the bundled sample audio

## Testing
- cargo test --no-default-features --features whisper
- pytest python_tests

------
https://chatgpt.com/codex/tasks/task_e_68d089e31e1c83218d7ca2acbc00a0fe