### PR TITLE
Implement floating pane workspace for realtime assistant

### DIFF
--- a/README.md
+++ b/README.md
@@ -65,14 +65,25 @@ The Electron app provides:
 - **Model configuration:** Select either:
   - Parakeet: Choose the directory `models/parakeet-tdt-0.6b-v3-int8`
   - Whisper: Choose the file `models/whisper-medium-q4_1.bin`
-- **Live transcript:** Real-time transcription of your speech
-- **AI-generated notes:** Bullet-point summaries created by OpenAI (requires API key)
+- **Live transcript pane:** Always-on transcript with draggable Mac-style chrome
+- **Floating AI panes:** Add realtime note takers, follow-up question trackers, action item detectors, and more
 - **Language selection:** Optional language hint for better accuracy
 
 Notes:
 - On macOS, Metal acceleration is used automatically when available
-- Without an OpenAI API key, transcription still works but notes won't be generated
+- Without an OpenAI API key, the transcript still works but AI panes stay disabled
+- Pane layouts are persisted locally so your workspace opens exactly where you left it
 - The app maintains a 30-second audio buffer for optimal transcription
+
+For a deeper dive into turning the app into a full realtime meeting copilot with floating AI panes (notes, follow-ups, decisions, and more), see [`docs/realtime-pane-architecture.md`](docs/realtime-pane-architecture.md).
+
+### Floating Pane Workspace
+
+1. **Add panes from templates:** Use the **Add AI pane** dropdown to spawn curated panes such as Note Taker, Follow-up Questions, Action Items, and Decisions.
+2. **Drag panes anywhere:** Each pane floats above the canvas with magnetic snapping. The layout is saved automatically per device so Mac Mission Control spaces stay consistent across launches.
+3. **Customize prompts:** Click the ✎ button on a pane to edit its instructions, switch models, or adjust system guidance. Use the **Custom pane** button to craft completely new prompts; the app injects the live transcript wherever you place `{{transcript}}`.
+4. **Force refresh or close:** The ↻ button requests an immediate update. The ✕ button removes a pane from the workspace; you can always add it back later.
+5. **API key required for AI panes:** When no `OPENAI_API_KEY` is present, panes stay in a disabled state and explain how to enable them while the transcript continues to run offline.
 
 ### CLI-Only Streaming
 

--- a/docs/realtime-pane-architecture.md
+++ b/docs/realtime-pane-architecture.md
@@ -1,0 +1,141 @@
+# Realtime Meeting Assistant Pane Architecture
+
+## Vision
+
+Deliver a Mac-first realtime meeting copilot where transcription is the anchor pane and users can fan out new floating panes that reason over the live conversation. Each pane is a focused AI worker with its own prompt, memory window, and output format, giving the facilitator a cockpit-like workspace for capturing notes, driving follow-ups, and exploring insights while the meeting is still in flight.
+
+## Experience Pillars
+
+1. **Transcript as the source of truth**
+   - Always-on "Transcript" pane shows a fully scrolling live feed with turn detection and speaker labeling.
+   - Users can pin/highlight segments. Highlights become structured events other panes can consume.
+
+2. **Composable floating panes**
+   - Users spawn panes from a tray of templates (Notes, Follow-ups, Decisions, Risks, Timer, Whiteboard, Custom prompt).
+   - Panes float above the canvas with magnetic snapping, resizable edges, and multi-monitor awareness on macOS Mission Control.
+   - Pane layout is persisted per meeting and can be saved/loaded as "workspaces" (e.g., Standup, Client Call).
+
+3. **Realtime intelligence**
+   - Every pane subscribes to the streaming transcript bus, runs its own incremental reasoning loop, and renders updates in near realtime.
+   - Panes can emit structured events (e.g., new action item) that feed back to other panes or external integrations.
+
+4. **Keyboard-first control**
+   - Global hotkeys (macOS `⌥` + `Space`) to summon the pane palette, cycle panes, and drop highlights.
+   - Command palette for spawning panes, toggling prompts, exporting notes.
+
+5. **Assistive automation**
+   - Built-in automations chain panes: e.g., when the Follow-ups pane logs an item, the Calendar pane suggests scheduling, and the Email Draft pane prepares outreach.
+
+## Pane Types & Default Prompts
+
+| Pane | Purpose | Prompt Characteristics |
+|------|---------|------------------------|
+| Transcript (mandatory) | Show live transcript with speaker diarization, timestamps, highlight markers. | No prompt; raw stream with inline analytics (confidence, filler word detection). |
+| Note Taker | Rolling bullet summary aligned to timestamps, grouping by topic. | Prompt focuses on succinct bullets, highlight decisions, questions, blockers. |
+| Follow-up Questions | Capture questions raised or implied during the meeting. | Prompt scans for interrogative phrases and context gaps; suggests clarifying questions. |
+| Action Items | Extract tasks with owner, due date hints, dependencies. | Prompt enforces schema `{summary, owner?, due?, priority}`; asks follow-up if data missing. |
+| Decisions | Track agreed outcomes, rationale, dissent. | Prompt flags decision language, ties back to transcript snippet IDs. |
+| Sentiment Pulse | Chart tone shifts across speakers in real time. | Prompt quantifies sentiment/emotion per minute, surfaces tension or excitement. |
+| Knowledge Lookup | Surfaces relevant documents or previous meeting notes via embeddings. | Prompt uses conversation context + retrieval to recommend artifacts. |
+| Custom Pane | User-defined prompt with optional schema and visualization template. | Advanced settings: temperature, model, context window size. |
+
+## Interaction Model
+
+- **Pane Palette:** Accessible via toolbar button or shortcut; shows grid of templates and recently used custom prompts.
+- **Pane Config Drawer:** Each pane has a settings drawer for prompt editing, memory controls (buffer size, summary frequency), export toggles.
+- **Data Pins:** Drag text from transcript into a pane to anchor reasoning. Panes treat pins as high-priority context.
+- **Insight Feed:** Unified activity stream that logs events emitted by panes (new task, follow-up, decision) for quick review/export.
+
+## System Architecture
+
+### High-Level Flow
+
+```
+Audio Input → Streaming Engine (Rust) → Transcript Event Bus (Electron preload) → Pane Workers (Renderer threads) → UI Panes
+```
+
+1. **Rust Streaming Engine** (`realtime_cli` embedded via Neon or IPC): captures audio, performs on-device ASR (Whisper/Parakeet), emits JSON chunks with tokens, timestamps, and speaker labels.
+2. **Transcript Event Bus** (Electron preload using `contextBridge`): normalizes ASR output, maintains rolling buffer (configurable 5–10 minutes), publishes events via RxJS observables to renderer panes.
+3. **Pane Workers**
+   - Each pane instantiates a lightweight worker (Web Worker or node `worker_threads`) responsible for prompt orchestration.
+   - Worker receives transcript delta events, maintains a local context window, triggers incremental LLM calls (OpenAI Realtime API or `responses` streaming) using function/tool outputs where needed.
+   - For on-device summarization, leverage Whisper's token-level confidence to gate updates.
+4. **State Store**
+   - Use Zustand or Recoil for pane layout and shared state. Persist to disk via Electron Store (`~/Library/Application Support/TranscribeRS/state.json`).
+   - Meeting timeline stored in SQLite (via `better-sqlite3`) enabling cross-pane queries.
+5. **Rendering Layer**
+   - React + Tailwind (or existing CSS) to render panes with GPU-accelerated transforms for smooth dragging.
+   - Use `react-rnd` for resize/drag, enhanced with macOS-style rubber-banding.
+
+### Streaming Context Management
+
+- **Incremental Summaries:** Pane worker keeps a sliding window (e.g., last 90 seconds) plus distilled memory of previous segments using auto-summarization triggered by token thresholds.
+- **Backpressure:** If multiple panes request LLM updates simultaneously, queue them via priority scheduler; transcript pane always real-time.
+- **Model Selection:** Default to `gpt-4o-mini-transcribe` for speed; allow user to pin panes to faster or smarter models.
+- **Failover:** If API latency spikes, panes fall back to local heuristics (e.g., regex for action items) until connection recovers.
+
+## Advanced Capabilities
+
+### Meeting Timeline & Replay
+
+- Store transcript with pane-emitted events; allow scrubber to replay conversation and re-run panes retroactively.
+- Generate time-aligned exports (Markdown, Notion, Apple Notes) preserving pane outputs.
+
+### Collaboration
+
+- AirDrop-style share: broadcast pane layouts to nearby Macs via `NSSharingService`.
+- Shared sessions: host invites others, panes sync via WebRTC data channel, enabling collaborative note editing.
+
+### Automations & Integrations
+
+- **Calendar sync:** Action Items with due dates can create Calendar reminders via Apple EventKit.
+- **Email drafts:** When Follow-up Questions pane flags open issues, auto-draft recap email in dedicated pane.
+- **Task managers:** Push tasks to Things, OmniFocus, Asana using pane-specific connectors.
+
+## Mac-Specific Optimizations
+
+- Utilize `NSWindow` APIs for native-feel floating panes, including vibrancy/blur effects and snapping to screen edges.
+- Support Mac trackpad gestures for pane management (three-finger swipe to switch workspaces, pinch to cluster panes).
+- Enable system-wide shortcut registration through `electron-traywindow` for quick capture outside the main window.
+- Leverage macOS dictation permissions prompts and store microphone consent states in the Keychain.
+
+## Telemetry & Reliability
+
+- Local analytics measure pane latency, LLM call volume, and transcription accuracy (confidence scores) to tune prompts.
+- Offline cache ensures panes resume gracefully after temporary disconnects.
+- Health dashboard pane monitors CPU/GPU usage and ASR backlog so users can react if performance dips during long meetings.
+
+## Implementation Roadmap
+
+1. **Foundations (Weeks 1–3)**
+   - Refactor transcript handling into shared event bus.
+   - Build pane manager with add/remove/reorder/persist capabilities.
+   - Implement Transcript + Note Taker panes using worker model.
+
+2. **Pane Expansion (Weeks 4–6)**
+   - Add Follow-up Questions, Action Items, Decisions panes with schema outputs.
+   - Integrate highlight pins and insight feed.
+   - Introduce custom pane builder UI.
+
+3. **Polish & Automations (Weeks 7–9)**
+   - Keyboard shortcuts, workspace presets, export pipelines.
+   - Calendar/email/task integrations for emitted events.
+   - Performance tuning on Apple Silicon (Metal profiling, concurrency budgets).
+
+4. **Collaboration & Advanced Features (Weeks 10+)**
+   - Shared sessions, timeline replay, advanced sentiment/knowledge panes.
+   - Deeper macOS-native window chrome and multi-display support.
+
+## Success Metrics
+
+- < 2s median latency from spoken word to pane update.
+- 90% of meetings exported with complete action items and decisions captured.
+- > 70% weekly active users leverage more than three panes per meeting.
+- Positive NPS feedback emphasizing reduced post-meeting follow-up time.
+
+## Open Questions
+
+- How to price pane usage if different LLM tiers incur varying costs?
+- Should panes be allowed to call each other (e.g., action item triggers follow-up) or only communicate via events?
+- What governance controls are needed for sensitive meeting data when panes hit external APIs?
+

--- a/electron/__tests__/pane-manager.test.js
+++ b/electron/__tests__/pane-manager.test.js
@@ -1,0 +1,75 @@
+const { PaneManager } = require('../pane-manager');
+
+function flushAsync() {
+  return new Promise((resolve) => setImmediate(resolve));
+}
+
+describe('PaneManager', () => {
+  test('emits structured list updates when LLM is available', async () => {
+    const updates = [];
+    const openaiClient = {
+      responses: {
+        create: jest.fn(() =>
+          Promise.resolve({
+            output_text: JSON.stringify({ bullets: ['First', 'Second'] }),
+          })
+        ),
+      },
+    };
+
+    const manager = new PaneManager({
+      openaiClient,
+      onUpdate: (payload) => updates.push(payload),
+    });
+
+    manager.setPanes([
+      {
+        id: 'notes',
+        title: 'Notes',
+        variant: 'list',
+        systemPrompt: 'system',
+        promptTemplate: 'Transcript\n{{transcript}}',
+        response: { type: 'json_list', field: 'bullets' },
+        throttleMs: 800,
+      },
+    ]);
+
+    manager.setTranscript({
+      text: 'hello world',
+      segments: [{ start: 0, end: 2, text: 'hello world' }],
+    });
+
+    manager.forceRefresh('notes');
+    await flushAsync();
+    await flushAsync();
+
+    expect(openaiClient.responses.create).toHaveBeenCalled();
+    const readyUpdate = updates.find((update) => update.status === 'ready');
+    expect(readyUpdate).toBeTruthy();
+    expect(readyUpdate.items).toEqual(['First', 'Second']);
+  });
+
+  test('reports unavailable status when no LLM client is configured', () => {
+    const updates = [];
+    const manager = new PaneManager({
+      openaiClient: null,
+      onUpdate: (payload) => updates.push(payload),
+    });
+
+    manager.setPanes([
+      {
+        id: 'actions',
+        title: 'Action Items',
+        variant: 'list',
+        systemPrompt: 'system',
+        promptTemplate: 'Transcript\n{{transcript}}',
+        response: { type: 'json_list', field: 'items' },
+      },
+    ]);
+
+    manager.setTranscript({ text: '', segments: [] });
+
+    const finalUpdate = updates[updates.length - 1];
+    expect(finalUpdate.status).toBe('llm-unavailable');
+  });
+});

--- a/electron/pane-manager.js
+++ b/electron/pane-manager.js
@@ -1,0 +1,651 @@
+const { extractResponseText, formatTimestamp } = require('./session-utils');
+
+const DEFAULT_MODEL = 'gpt-5-nano';
+const MIN_THROTTLE_MS = 600;
+const MAX_TRANSCRIPT_CHARS = 6000;
+const DEFAULT_SYSTEM_PROMPT =
+  'You are a realtime meeting copilot pane. You listen to the conversation, stay focused on your specialty, and respond with concise updates that are safe to render live in front of participants.';
+
+function clampNumber(value, fallback) {
+  if (typeof value !== 'number' || Number.isNaN(value)) {
+    return fallback;
+  }
+  return value;
+}
+
+function safeString(value, fallback = '') {
+  if (typeof value === 'string') {
+    return value;
+  }
+  if (value === undefined || value === null) {
+    return fallback;
+  }
+  return String(value);
+}
+
+function sanitizePromptTemplate(template) {
+  const trimmed = safeString(template).trim();
+  if (!trimmed) {
+    return 'Live transcript so far:\n{{transcript}}\n\nSummarize the most recent moments.';
+  }
+  return trimmed;
+}
+
+function ensureTranscriptPlaceholder(template) {
+  if (template.includes('{{transcript}}')) {
+    return template;
+  }
+  return `${template}\n\nTranscript:\n{{transcript}}`;
+}
+
+function sliceTranscriptSegments(segments, { maxSegments }) {
+  if (!Array.isArray(segments) || segments.length === 0) {
+    return [];
+  }
+  const limit = Math.max(1, Math.min(segments.length, maxSegments || 40));
+  return segments.slice(-limit);
+}
+
+function buildSegmentLines(segments) {
+  return segments
+    .map((segment) => {
+      const text = safeString(segment?.text).trim();
+      if (!text) {
+        return null;
+      }
+      const timestamp = formatTimestamp(segment?.start, segment?.end);
+      return `${timestamp} ${text}`.trim();
+    })
+    .filter(Boolean);
+}
+
+function trimTranscriptText(lines) {
+  if (!Array.isArray(lines) || !lines.length) {
+    return '';
+  }
+  let joined = lines.join('\n');
+  if (joined.length <= MAX_TRANSCRIPT_CHARS) {
+    return joined;
+  }
+  const copy = [...lines];
+  while (joined.length > MAX_TRANSCRIPT_CHARS && copy.length > 1) {
+    copy.shift();
+    joined = copy.join('\n');
+  }
+  return joined;
+}
+
+function buildJsonListSchema(responseConfig) {
+  const field = responseConfig.field || 'items';
+  return {
+    type: 'json_schema',
+    json_schema: {
+      name: responseConfig.schemaName || 'pane_output',
+      schema: {
+        type: 'object',
+        properties: {
+          [field]: {
+            type: 'array',
+            items: { type: 'string' },
+          },
+        },
+        required: [field],
+      },
+    },
+  };
+}
+
+function buildJsonObjectSchema(responseConfig) {
+  const field = responseConfig.field || 'items';
+  const propertyEntries = Object.entries(responseConfig.properties || {}).reduce(
+    (acc, [key, value]) => {
+      acc[key] = {
+        type: value?.type === 'string' ? 'string' : 'string',
+        description: safeString(value?.description).trim() || undefined,
+      };
+      return acc;
+    },
+    {}
+  );
+
+  const required = Array.isArray(responseConfig.requiredFields)
+    ? responseConfig.requiredFields.filter((entry) => typeof entry === 'string' && entry.trim())
+    : [];
+
+  return {
+    type: 'json_schema',
+    json_schema: {
+      name: responseConfig.schemaName || 'pane_output',
+      schema: {
+        type: 'object',
+        properties: {
+          [field]: {
+            type: 'array',
+            items: {
+              type: 'object',
+              properties: propertyEntries,
+              required,
+            },
+          },
+        },
+        required: [field],
+      },
+    },
+  };
+}
+
+class PaneManager {
+  constructor({ openaiClient, onUpdate, onRemove } = {}) {
+    this.openaiClient = openaiClient || null;
+    this.onUpdate = typeof onUpdate === 'function' ? onUpdate : null;
+    this.onRemove = typeof onRemove === 'function' ? onRemove : null;
+    this.panes = new Map();
+    this.transcript = { text: '', segments: [] };
+  }
+
+  setOpenAIClient(client) {
+    this.openaiClient = client || null;
+    for (const pane of this.panes.values()) {
+      if (!this.openaiClient) {
+        pane.status = 'llm-unavailable';
+      } else if (!this.transcript.text?.trim()) {
+        pane.status = 'waiting';
+      }
+      this.emitUpdate(pane);
+    }
+  }
+
+  setPanes(configs) {
+    const normalizedConfigs = Array.isArray(configs) ? configs : [];
+    const nextIds = new Set();
+
+    for (const config of normalizedConfigs) {
+      const normalized = this.normalizeConfig(config);
+      if (!normalized) {
+        // eslint-disable-next-line no-continue
+        continue;
+      }
+      nextIds.add(normalized.id);
+      this.upsertPane(normalized);
+    }
+
+    for (const existingId of this.panes.keys()) {
+      if (!nextIds.has(existingId)) {
+        this.removePane(existingId);
+      }
+    }
+  }
+
+  setTranscript(transcript) {
+    const text = safeString(transcript?.text);
+    const segments = Array.isArray(transcript?.segments) ? transcript.segments : [];
+    this.transcript = { text, segments };
+
+    for (const pane of this.panes.values()) {
+      this.schedulePane(pane);
+    }
+  }
+
+  resetOutputs() {
+    for (const pane of this.panes.values()) {
+      pane.items = [];
+      pane.text = '';
+      pane.raw = '';
+      pane.structured = [];
+      pane.error = null;
+      pane.lastRunAt = 0;
+      if (!this.openaiClient) {
+        pane.status = 'llm-unavailable';
+      } else {
+        pane.status = 'waiting';
+      }
+      this.clearTimer(pane);
+      this.emitUpdate(pane);
+    }
+  }
+
+  removePane(id) {
+    const pane = this.panes.get(id);
+    if (!pane) {
+      return;
+    }
+    this.clearTimer(pane);
+    this.panes.delete(id);
+    if (this.onRemove) {
+      this.onRemove(id);
+    }
+  }
+
+  reset() {
+    for (const pane of this.panes.values()) {
+      this.clearTimer(pane);
+    }
+    this.panes.clear();
+  }
+
+  forceRefresh(paneId) {
+    const pane = this.panes.get(paneId);
+    if (!pane) {
+      return;
+    }
+    this.clearTimer(pane);
+    pane.pending = false;
+    this.runPane(pane, { immediate: true });
+  }
+
+  normalizeConfig(config) {
+    if (!config || typeof config !== 'object') {
+      return null;
+    }
+
+    const id = safeString(config.id).trim();
+    if (!id) {
+      return null;
+    }
+
+    const title = safeString(config.title, 'AI Pane').trim() || 'AI Pane';
+    const variant = config.variant === 'text' ? 'text' : 'list';
+    const systemPrompt = safeString(config.systemPrompt).trim() || DEFAULT_SYSTEM_PROMPT;
+    const promptTemplate = ensureTranscriptPlaceholder(sanitizePromptTemplate(config.promptTemplate));
+    const throttleMsRaw = clampNumber(config.throttleMs, NaN);
+    const throttleMs = Number.isFinite(throttleMsRaw)
+      ? Math.max(MIN_THROTTLE_MS, Math.floor(throttleMsRaw))
+      : 1500;
+    const model = safeString(config.model, DEFAULT_MODEL).trim() || DEFAULT_MODEL;
+    const maxSegments = Number.isFinite(config.maxSegments) ? Math.max(6, Math.floor(config.maxSegments)) : 36;
+    const maxOutputTokens = Number.isFinite(config.maxOutputTokens)
+      ? Math.max(100, Math.floor(config.maxOutputTokens))
+      : 400;
+
+    const response = this.normalizeResponseConfig(config.response, variant);
+
+    return {
+      id,
+      title,
+      variant,
+      systemPrompt,
+      promptTemplate,
+      throttleMs,
+      model,
+      maxSegments,
+      maxOutputTokens,
+      response,
+      templateId: config.templateId ? safeString(config.templateId).trim() : undefined,
+      allowPromptEdit: config.allowPromptEdit !== false,
+    };
+  }
+
+  normalizeResponseConfig(responseConfig, variant) {
+    const safeConfig = responseConfig && typeof responseConfig === 'object' ? responseConfig : {};
+
+    if (safeConfig.type === 'json_objects') {
+      return {
+        type: 'json_objects',
+        field: safeString(safeConfig.field, 'items'),
+        schemaName: safeString(safeConfig.schemaName, 'pane_output'),
+        properties: safeConfig.properties && typeof safeConfig.properties === 'object' ? safeConfig.properties : {},
+        requiredFields: Array.isArray(safeConfig.requiredFields)
+          ? safeConfig.requiredFields.filter((entry) => typeof entry === 'string' && entry.trim())
+          : [],
+        displayFields: Array.isArray(safeConfig.displayFields)
+          ? safeConfig.displayFields.filter((entry) => typeof entry === 'string' && entry.trim())
+          : undefined,
+        fallbackFields: Array.isArray(safeConfig.fallbackFields)
+          ? safeConfig.fallbackFields.filter((entry) => typeof entry === 'string' && entry.trim())
+          : undefined,
+      };
+    }
+
+    if (safeConfig.type === 'json_list') {
+      return {
+        type: 'json_list',
+        field: safeString(safeConfig.field, 'items'),
+        schemaName: safeString(safeConfig.schemaName, 'pane_output'),
+        fallbackFields: Array.isArray(safeConfig.fallbackFields)
+          ? safeConfig.fallbackFields.filter((entry) => typeof entry === 'string' && entry.trim())
+          : undefined,
+      };
+    }
+
+    if (safeConfig.type === 'text_list') {
+      return { type: 'text_list' };
+    }
+
+    if (variant === 'text') {
+      return { type: 'text' };
+    }
+
+    return { type: 'text_list' };
+  }
+
+  upsertPane(config) {
+    let pane = this.panes.get(config.id);
+    if (!pane) {
+      pane = {
+        id: config.id,
+        config,
+        status: this.openaiClient ? 'waiting' : 'llm-unavailable',
+        items: [],
+        text: '',
+        raw: '',
+        structured: [],
+        timer: null,
+        pending: false,
+        running: false,
+        lastRunAt: 0,
+        error: null,
+      };
+      this.panes.set(config.id, pane);
+    } else {
+      this.clearTimer(pane);
+      pane.config = config;
+      pane.error = null;
+      if (!this.openaiClient) {
+        pane.status = 'llm-unavailable';
+      }
+    }
+
+    this.emitUpdate(pane);
+    this.schedulePane(pane, { immediate: true });
+  }
+
+  clearTimer(pane) {
+    if (pane.timer) {
+      clearTimeout(pane.timer);
+      pane.timer = null;
+    }
+  }
+
+  schedulePane(pane, { immediate = false } = {}) {
+    if (!pane || pane.running) {
+      if (pane) {
+        pane.pending = true;
+      }
+      return;
+    }
+
+    if (!this.openaiClient) {
+      pane.status = 'llm-unavailable';
+      this.emitUpdate(pane);
+      return;
+    }
+
+    if (!this.transcript.text.trim()) {
+      pane.status = 'waiting';
+      this.emitUpdate(pane);
+      return;
+    }
+
+    const now = Date.now();
+    const elapsed = now - (pane.lastRunAt || 0);
+    const waitTime = Math.max(0, pane.config.throttleMs - elapsed);
+
+    if (immediate || waitTime === 0) {
+      this.runPane(pane);
+      return;
+    }
+
+    if (pane.timer) {
+      return;
+    }
+
+    pane.timer = setTimeout(() => {
+      pane.timer = null;
+      this.runPane(pane);
+    }, waitTime);
+  }
+
+  async runPane(pane) {
+    if (!pane || pane.running) {
+      return;
+    }
+
+    if (!this.openaiClient) {
+      pane.status = 'llm-unavailable';
+      this.emitUpdate(pane);
+      return;
+    }
+
+    const transcriptExcerpt = this.buildTranscriptExcerpt(pane.config);
+    if (!transcriptExcerpt.trim()) {
+      pane.status = 'waiting';
+      this.emitUpdate(pane);
+      return;
+    }
+
+    pane.running = true;
+    pane.pending = false;
+    pane.status = 'generating';
+    pane.error = null;
+    this.emitUpdate(pane);
+
+    try {
+      const messages = this.buildMessages(pane.config, transcriptExcerpt);
+      const request = {
+        model: pane.config.model || DEFAULT_MODEL,
+        input: messages,
+        max_output_tokens: pane.config.maxOutputTokens,
+      };
+
+      const responseFormat = this.buildResponseFormat(pane.config.response);
+      if (responseFormat) {
+        request.response_format = responseFormat;
+      }
+
+      const response = await this.openaiClient.responses.create(request);
+      const parsed = this.parseResponse(response, pane.config.response);
+
+      pane.items = Array.isArray(parsed.items) ? parsed.items : [];
+      pane.text = safeString(parsed.text).trim();
+      pane.raw = safeString(parsed.raw).trim();
+      pane.structured = Array.isArray(parsed.structured) ? parsed.structured : [];
+      pane.status = 'ready';
+      pane.lastRunAt = Date.now();
+    } catch (error) {
+      pane.error = safeString(error?.message, 'Unknown error');
+      pane.status = 'error';
+    } finally {
+      pane.running = false;
+      this.emitUpdate(pane);
+      if (pane.pending) {
+        pane.pending = false;
+        this.schedulePane(pane);
+      }
+    }
+  }
+
+  buildMessages(config, transcriptExcerpt) {
+    const promptWithTranscript = config.promptTemplate.replace('{{transcript}}', transcriptExcerpt);
+    return [
+      { role: 'system', content: config.systemPrompt || DEFAULT_SYSTEM_PROMPT },
+      { role: 'user', content: promptWithTranscript },
+    ];
+  }
+
+  buildTranscriptExcerpt(config) {
+    const segments = sliceTranscriptSegments(this.transcript.segments, {
+      maxSegments: config.maxSegments,
+    });
+    if (!segments.length) {
+      return safeString(this.transcript.text);
+    }
+    const lines = buildSegmentLines(segments);
+    return trimTranscriptText(lines);
+  }
+
+  buildResponseFormat(responseConfig) {
+    if (!responseConfig || typeof responseConfig !== 'object') {
+      return null;
+    }
+    if (responseConfig.type === 'json_list') {
+      return buildJsonListSchema(responseConfig);
+    }
+    if (responseConfig.type === 'json_objects') {
+      return buildJsonObjectSchema(responseConfig);
+    }
+    return null;
+  }
+
+  parseResponse(response, responseConfig) {
+    const rawOutput = extractResponseText(response);
+
+    if (!responseConfig || typeof responseConfig !== 'object') {
+      return { text: rawOutput, raw: rawOutput };
+    }
+
+    if (responseConfig.type === 'json_list') {
+      const items = this.parseListOutput(rawOutput, {
+        primary: responseConfig.field,
+        fallback: responseConfig.fallbackFields,
+      });
+      return { items, raw: rawOutput };
+    }
+
+    if (responseConfig.type === 'json_objects') {
+      const parsed = this.parseObjectListOutput(rawOutput, responseConfig);
+      return parsed;
+    }
+
+    if (responseConfig.type === 'text_list') {
+      const items = this.parsePlaintextList(rawOutput);
+      return { items, raw: rawOutput };
+    }
+
+    return { text: rawOutput, raw: rawOutput };
+  }
+
+  parsePlaintextList(rawOutput) {
+    return safeString(rawOutput)
+      .split(/\n+/)
+      .map((line) => line.replace(/^[-•\s]+/, '').trim())
+      .filter(Boolean);
+  }
+
+  parseListOutput(rawOutput, options = {}) {
+    const text = safeString(rawOutput).trim();
+    if (!text) {
+      return [];
+    }
+
+    try {
+      const parsed = JSON.parse(text);
+      const keys = [options.primary, ...(options.fallback || [])].filter(Boolean);
+      for (const key of keys) {
+        if (Array.isArray(parsed?.[key])) {
+          return parsed[key].map((entry) => safeString(entry).trim()).filter(Boolean);
+        }
+      }
+    } catch (error) {
+      // fall back to plaintext parsing
+    }
+
+    return this.parsePlaintextList(text);
+  }
+
+  parseObjectListOutput(rawOutput, responseConfig) {
+    const text = safeString(rawOutput).trim();
+    if (!text) {
+      return { items: [], structured: [], raw: rawOutput };
+    }
+
+    let structured = [];
+    const field = responseConfig.field || 'items';
+
+    try {
+      const parsed = JSON.parse(text);
+      if (Array.isArray(parsed?.[field])) {
+        structured = parsed[field]
+          .map((entry) => {
+            if (!entry || typeof entry !== 'object') {
+              return null;
+            }
+            const normalized = {};
+            for (const [key, value] of Object.entries(responseConfig.properties || {})) {
+              const val = entry[key];
+              if (val === undefined || val === null) {
+                // eslint-disable-next-line no-continue
+                continue;
+              }
+              normalized[key] = safeString(val).trim();
+            }
+            for (const key of Object.keys(entry)) {
+              if (!(key in normalized) && typeof entry[key] === 'string') {
+                normalized[key] = safeString(entry[key]).trim();
+              }
+            }
+            return normalized;
+          })
+          .filter(Boolean);
+      }
+    } catch (error) {
+      structured = [];
+    }
+
+    if (!structured.length) {
+      const fallbackItems = this.parsePlaintextList(text);
+      return { items: fallbackItems, structured: [], raw: rawOutput };
+    }
+
+    const displayFields = Array.isArray(responseConfig.displayFields)
+      ? responseConfig.displayFields
+      : Object.keys(responseConfig.properties || {});
+
+    const items = structured.map((entry) => {
+      const primaryKey = responseConfig.requiredFields?.[0] || displayFields?.[0] || 'summary';
+      const primary = safeString(entry[primaryKey]).trim();
+      const details = [];
+      for (const fieldKey of displayFields) {
+        if (fieldKey === primaryKey) {
+          // eslint-disable-next-line no-continue
+          continue;
+        }
+        const value = safeString(entry[fieldKey]).trim();
+        if (value) {
+          const label = fieldKey.replace(/_/g, ' ');
+          details.push(`${label}: ${value}`);
+        }
+      }
+      if (!primary && details.length) {
+        return details.join(' • ');
+      }
+      if (!primary) {
+        return '';
+      }
+      if (!details.length) {
+        return primary;
+      }
+      return `${primary} (${details.join(' • ')})`;
+    });
+
+    return {
+      items: items.filter(Boolean),
+      structured,
+      raw: rawOutput,
+    };
+  }
+
+  emitUpdate(pane) {
+    if (!this.onUpdate) {
+      return;
+    }
+    this.onUpdate({
+      id: pane.id,
+      title: pane.config.title,
+      variant: pane.config.variant,
+      status: pane.status,
+      items: Array.isArray(pane.items) ? pane.items : [],
+      text: safeString(pane.text),
+      error: pane.error || null,
+      raw: safeString(pane.raw),
+      structured: Array.isArray(pane.structured) ? pane.structured : [],
+      lastUpdated: pane.lastRunAt || null,
+      templateId: pane.config.templateId,
+      allowPromptEdit: pane.config.allowPromptEdit,
+      model: pane.config.model,
+    });
+  }
+}
+
+module.exports = {
+  PaneManager,
+};

--- a/electron/pane-templates.js
+++ b/electron/pane-templates.js
@@ -1,0 +1,102 @@
+const NOTE_TAKER_PROMPT = `Live transcript so far:\n{{transcript}}\n\nSummarize the conversation into concise, chronological bullets. Each bullet should capture a single idea and mention owners, blockers, decisions, or metrics when present. Return JSON with a \\"bullets\\" array ordered chronologically.`;
+
+const FOLLOW_UP_PROMPT = `Here is the live transcript:\n{{transcript}}\n\nIdentify clarifying or follow-up questions the team should ask. Prioritize questions that unblock decisions or surface missing context. Return JSON with a \\"questions\\" array.`;
+
+const ACTION_ITEMS_PROMPT = `Transcript excerpt:\n{{transcript}}\n\nExtract clear action items. Each task should have a short summary plus optional owner, due date, and priority. When information is missing but strongly implied, include it with a trailing "(?)". Return JSON with an \\"items\\" array of objects { summary, owner?, due?, priority? }.`;
+
+const DECISIONS_PROMPT = `Meeting transcript:\n{{transcript}}\n\nCapture decisions or agreements that were reached. Include the rationale or supporting context when it is available. Return JSON with a \\"decisions\\" array of objects { decision, rationale?, next_step? }.`;
+
+const DEFAULT_PANE_TEMPLATES = [
+  {
+    templateId: 'note-taker',
+    title: 'Note Taker',
+    description: 'Chronological meeting notes generated in real time.',
+    variant: 'list',
+    systemPrompt:
+      'You are a meticulous real-time meeting note taker. Produce chronological, high-signal bullets that help someone recall the conversation minutes later. Keep language short and specific.',
+    promptTemplate: NOTE_TAKER_PROMPT,
+    response: {
+      type: 'json_list',
+      schemaName: 'chronological_notes',
+      field: 'bullets',
+      fallbackFields: ['notes'],
+    },
+    throttleMs: 1400,
+    maxSegments: 36,
+    maxOutputTokens: 400,
+    allowPromptEdit: true,
+  },
+  {
+    templateId: 'follow-ups',
+    title: 'Follow-up Questions',
+    description: 'Suggest clarifying questions to keep the meeting moving.',
+    variant: 'list',
+    systemPrompt:
+      'You monitor live meetings and surface clarifying questions that should be asked before moving on. Focus on actionable gaps.',
+    promptTemplate: FOLLOW_UP_PROMPT,
+    response: {
+      type: 'json_list',
+      schemaName: 'follow_up_questions',
+      field: 'questions',
+    },
+    throttleMs: 1800,
+    maxSegments: 32,
+    maxOutputTokens: 320,
+    allowPromptEdit: true,
+  },
+  {
+    templateId: 'action-items',
+    title: 'Action Items',
+    description: 'Track commitments with owners and due dates.',
+    variant: 'list',
+    systemPrompt:
+      'You listen to meetings and capture concrete follow-up tasks. When the team agrees to do something, you record it as an action item with owner and due date when possible.',
+    promptTemplate: ACTION_ITEMS_PROMPT,
+    response: {
+      type: 'json_objects',
+      schemaName: 'action_items',
+      field: 'items',
+      properties: {
+        summary: { type: 'string', description: 'Concise description of the task.' },
+        owner: { type: 'string', description: 'Person responsible for the task.', optional: true },
+        due: { type: 'string', description: 'Due date or time expectation.', optional: true },
+        priority: { type: 'string', description: 'Priority or urgency indicator.', optional: true },
+      },
+      requiredFields: ['summary'],
+      displayFields: ['owner', 'due', 'priority'],
+    },
+    throttleMs: 2200,
+    maxSegments: 40,
+    maxOutputTokens: 420,
+    allowPromptEdit: true,
+  },
+  {
+    templateId: 'decisions',
+    title: 'Decisions & Outcomes',
+    description: 'Log the choices that were made and why.',
+    variant: 'list',
+    systemPrompt:
+      'You capture decisions in real time so the team remembers what they agreed to. Highlight supporting rationale and resulting next steps.',
+    promptTemplate: DECISIONS_PROMPT,
+    response: {
+      type: 'json_objects',
+      schemaName: 'decision_log',
+      field: 'decisions',
+      properties: {
+        decision: { type: 'string', description: 'Statement of the decision that was made.' },
+        rationale: { type: 'string', description: 'Brief reason or evidence cited.', optional: true },
+        next_step: { type: 'string', description: 'Follow-up step triggered by the decision.', optional: true },
+      },
+      requiredFields: ['decision'],
+      displayFields: ['rationale', 'next_step'],
+    },
+    throttleMs: 2200,
+    maxSegments: 40,
+    maxOutputTokens: 420,
+    allowPromptEdit: true,
+  },
+];
+
+module.exports = {
+  DEFAULT_PANE_TEMPLATES,
+};

--- a/electron/preload.js
+++ b/electron/preload.js
@@ -6,7 +6,19 @@ contextBridge.exposeInMainWorld('electronAPI', {
   sendAudioChunk: (chunk) => ipcRenderer.send('audio-chunk', chunk),
   onTranscript: (callback) => ipcRenderer.on('transcript-update', (_event, data) => callback(data)),
   onStatus: (callback) => ipcRenderer.on('status-update', (_event, message) => callback(message)),
-  onNotes: (callback) => ipcRenderer.on('notes-update', (_event, data) => callback(data)),
-  onNotesStatus: (callback) => ipcRenderer.on('notes-status', (_event, status) => callback(status)),
-  onceNotesAvailability: (callback) => ipcRenderer.once('notes-availability', (_event, available) => callback(available)),
+  onPaneUpdate: (callback) => {
+    const handler = (_event, payload) => callback(payload);
+    ipcRenderer.on('pane-update', handler);
+    return () => ipcRenderer.removeListener('pane-update', handler);
+  },
+  onPaneRemoved: (callback) => {
+    const handler = (_event, paneId) => callback(paneId);
+    ipcRenderer.on('pane-removed', handler);
+    return () => ipcRenderer.removeListener('pane-removed', handler);
+  },
+  getPaneTemplates: () => ipcRenderer.invoke('pane:get-templates'),
+  setPaneConfigs: (configs) => ipcRenderer.invoke('pane:set-configs', configs),
+  requestPaneRefresh: (paneId) => ipcRenderer.invoke('pane:refresh', paneId),
+  oncePaneAvailability: (callback) =>
+    ipcRenderer.once('pane-llm-availability', (_event, available) => callback(available)),
 });

--- a/electron/renderer/index.html
+++ b/electron/renderer/index.html
@@ -7,7 +7,7 @@
       :root {
         font-family: "Inter", -apple-system, BlinkMacSystemFont, "Segoe UI", sans-serif;
         color: #101828;
-        background: #f4f5f7;
+        background: linear-gradient(180deg, #f8fafc 0%, #eef2ff 100%);
       }
 
       body {
@@ -21,7 +21,7 @@
         padding: 16px 24px;
         background: #101828;
         color: #fff;
-        box-shadow: 0 2px 6px rgba(16, 24, 40, 0.1);
+        box-shadow: 0 2px 6px rgba(16, 24, 40, 0.12);
       }
 
       header h1 {
@@ -43,10 +43,11 @@
         flex-wrap: wrap;
         gap: 16px;
         align-items: flex-end;
-        background: #fff;
+        background: rgba(255, 255, 255, 0.9);
+        backdrop-filter: blur(16px);
         padding: 16px;
-        border-radius: 12px;
-        box-shadow: 0 1px 2px rgba(16, 24, 40, 0.08);
+        border-radius: 16px;
+        box-shadow: 0 12px 32px rgba(15, 23, 42, 0.06);
       }
 
       .control-group {
@@ -63,132 +64,263 @@
 
       input,
       select {
-        border-radius: 8px;
+        border-radius: 10px;
         border: 1px solid #d0d5dd;
-        padding: 8px 10px;
+        padding: 9px 12px;
         font-size: 14px;
         background: #fff;
         color: #101828;
       }
 
+      select {
+        min-width: 200px;
+      }
+
       button {
-        border-radius: 8px;
+        border-radius: 10px;
         border: none;
         padding: 10px 18px;
         font-size: 14px;
         font-weight: 600;
         cursor: pointer;
+        transition: transform 0.12s ease, box-shadow 0.12s ease;
       }
 
       button.primary {
         background: #2563eb;
         color: #fff;
+        box-shadow: 0 6px 14px rgba(37, 99, 235, 0.24);
       }
 
       button.secondary {
-        background: #e4e7ec;
-        color: #344054;
+        background: rgba(37, 99, 235, 0.08);
+        color: #1d4ed8;
+        border: 1px solid rgba(37, 99, 235, 0.18);
       }
 
       button:disabled {
         opacity: 0.6;
         cursor: not-allowed;
+        transform: none;
+        box-shadow: none;
+      }
+
+      button:not(:disabled):hover {
+        transform: translateY(-1px);
       }
 
       .status-line {
         font-size: 13px;
         color: #475467;
         min-height: 18px;
+        padding: 4px 6px;
       }
 
-      .columns {
+      .pane-template-row {
+        display: flex;
+        gap: 8px;
+        align-items: center;
+        flex-wrap: wrap;
+      }
+
+      .pane-hint {
+        font-size: 12px;
+        color: #667085;
+      }
+
+      .workspace {
         flex: 1;
-        display: grid;
-        grid-template-columns: repeat(auto-fit, minmax(300px, 1fr));
-        gap: 16px;
+        position: relative;
+        min-height: 420px;
       }
 
-      .panel {
-        background: #fff;
-        border-radius: 12px;
-        padding: 18px;
+      .pane-canvas {
+        position: relative;
+        width: 100%;
+        height: 100%;
+        min-height: 420px;
+        border-radius: 20px;
+        background: rgba(255, 255, 255, 0.6);
+        box-shadow: inset 0 0 0 1px rgba(15, 23, 42, 0.05);
+        overflow: hidden;
+      }
+
+      .floating-pane {
+        position: absolute;
+        top: 24px;
+        left: 24px;
+        width: 360px;
+        max-width: 420px;
+        min-height: 240px;
         display: flex;
         flex-direction: column;
-        box-shadow: 0 1px 2px rgba(16, 24, 40, 0.08);
-        min-height: 0;
+        border-radius: 18px;
+        background: rgba(255, 255, 255, 0.95);
+        box-shadow: 0 18px 34px rgba(15, 23, 42, 0.18);
+        border: 1px solid rgba(148, 163, 184, 0.24);
+        transition: box-shadow 0.2s ease;
       }
 
-      .panel h2 {
-        margin: 0 0 12px;
-        font-size: 16px;
+      .floating-pane.dragging {
+        box-shadow: 0 20px 40px rgba(37, 99, 235, 0.28);
+      }
+
+      .pane-header {
+        display: flex;
+        align-items: center;
+        justify-content: space-between;
+        padding: 14px 18px 8px;
+        cursor: grab;
+        user-select: none;
+      }
+
+      .pane-title {
+        font-size: 15px;
         font-weight: 600;
-        color: #1d2939;
+        color: #1e293b;
       }
 
-      .scroll-panel {
+      .pane-actions {
+        display: flex;
+        gap: 6px;
+        align-items: center;
+      }
+
+      .pane-action {
+        border: none;
+        background: rgba(15, 23, 42, 0.06);
+        border-radius: 8px;
+        width: 28px;
+        height: 28px;
+        display: grid;
+        place-items: center;
+        font-size: 13px;
+        cursor: pointer;
+        transition: background 0.12s ease, transform 0.12s ease;
+      }
+
+      .pane-action:hover {
+        background: rgba(37, 99, 235, 0.15);
+        transform: translateY(-1px);
+      }
+
+      .pane-action:disabled {
+        opacity: 0.4;
+        cursor: not-allowed;
+        transform: none;
+      }
+
+      .pane-tag {
+        font-size: 11px;
+        font-weight: 600;
+        color: #1d4ed8;
+        background: rgba(37, 99, 235, 0.12);
+        border-radius: 999px;
+        padding: 4px 10px;
+      }
+
+      .pane-body {
+        flex: 1;
+        display: flex;
+        flex-direction: column;
+        padding: 4px 18px 18px;
+        gap: 10px;
+      }
+
+      .pane-status {
+        font-size: 12px;
+        color: #64748b;
+        min-height: 16px;
+      }
+
+      .pane-status.error {
+        color: #b91c1c;
+      }
+
+      .pane-content {
         flex: 1;
         overflow-y: auto;
-        padding-right: 4px;
-      }
-
-      .segment {
+        padding-right: 6px;
         display: flex;
-        gap: 12px;
-        padding: 8px 0;
-        border-bottom: 1px solid #f2f4f7;
+        flex-direction: column;
+        gap: 10px;
       }
 
-      .segment:last-child {
-        border-bottom: none;
+      .pane-content::-webkit-scrollbar {
+        width: 8px;
       }
 
-      .timestamp {
-        font-size: 12px;
-        font-weight: 600;
-        color: #475467;
-        min-width: 48px;
+      .pane-content::-webkit-scrollbar-thumb {
+        border-radius: 999px;
+        background: rgba(100, 116, 139, 0.35);
       }
 
-      .segment-text {
-        font-size: 14px;
-        line-height: 1.4;
-        color: #101828;
-        white-space: pre-wrap;
-      }
-
-      .notes-status {
-        font-size: 13px;
-        color: #667085;
-        margin-bottom: 12px;
-      }
-
-      .notes-list {
-        list-style: disc inside;
+      .pane-list {
+        list-style: none;
+        padding: 0;
+        margin: 0;
         display: flex;
         flex-direction: column;
         gap: 8px;
-        padding: 0;
-        margin: 0;
+      }
+
+      .pane-list li {
+        background: rgba(226, 232, 240, 0.6);
+        border-radius: 12px;
+        padding: 10px 12px;
         font-size: 14px;
-        color: #101828;
+        line-height: 1.4;
+        color: #0f172a;
+        border: 1px solid rgba(148, 163, 184, 0.28);
       }
 
-      .notes-list li {
-        background: #f8fafc;
-        border-radius: 10px;
-        padding: 10px 14px;
-        border: 1px solid #e2e8f0;
+      .pane-text-block {
+        font-size: 14px;
+        line-height: 1.55;
+        color: #0f172a;
+        white-space: pre-wrap;
+        background: rgba(241, 245, 249, 0.8);
+        border-radius: 12px;
+        padding: 12px 14px;
+        border: 1px solid rgba(148, 163, 184, 0.24);
       }
 
-      .placeholder {
+      .pane-placeholder {
         font-size: 13px;
-        color: #98a2b3;
+        color: #94a3b8;
+        padding: 12px 0;
+      }
+
+      .transcript-content {
+        font-family: "SF Mono", "Menlo", monospace;
+        font-size: 13px;
+        color: #0f172a;
+        display: flex;
+        flex-direction: column;
+        gap: 8px;
+      }
+
+      .transcript-segment {
+        display: flex;
+        gap: 10px;
+      }
+
+      .transcript-timestamp {
+        font-weight: 600;
+        color: #2563eb;
+        min-width: 56px;
+      }
+
+      @media (max-width: 1024px) {
+        .floating-pane {
+          width: min(100%, 360px);
+        }
       }
     </style>
   </head>
   <body>
     <header>
-      <h1>transcribe-rs realtime notes</h1>
+      <h1>transcribe-rs realtime meeting cockpit</h1>
     </header>
     <main>
       <section class="controls">
@@ -211,20 +343,34 @@
           <button id="startButton" class="primary">Start capture</button>
           <button id="stopButton" class="secondary" disabled>Stop</button>
         </div>
+        <div class="control-group">
+          <label for="paneTemplate">Add AI pane</label>
+          <div class="pane-template-row">
+            <select id="paneTemplate"></select>
+            <button id="addPaneButton" class="secondary">Add pane</button>
+            <button id="customPaneButton" class="secondary">Custom pane</button>
+          </div>
+          <div class="pane-hint" id="paneHint">Loading pane templates…</div>
+        </div>
       </section>
 
       <div class="status-line" id="status">Waiting to start…</div>
 
-      <section class="columns">
-        <article class="panel">
-          <h2>Live transcript</h2>
-          <div id="transcript" class="scroll-panel placeholder">No audio yet.</div>
-        </article>
-        <article class="panel">
-          <h2>Realtime notes</h2>
-          <div id="notesStatus" class="notes-status">Notes idle</div>
-          <ul id="notes" class="notes-list"></ul>
-        </article>
+      <section class="workspace">
+        <div id="paneCanvas" class="pane-canvas">
+          <article class="floating-pane transcript-pane" data-pane-id="transcript">
+            <div class="pane-header">
+              <div class="pane-title">Live transcript</div>
+              <div class="pane-actions">
+                <span class="pane-tag">Always on</span>
+              </div>
+            </div>
+            <div class="pane-body">
+              <div id="transcriptStatus" class="pane-status">No audio yet.</div>
+              <div id="transcript" class="pane-content transcript-content"></div>
+            </div>
+          </article>
+        </div>
       </section>
     </main>
     <script src="./utils.js"></script>

--- a/electron/renderer/renderer.js
+++ b/electron/renderer/renderer.js
@@ -1,10 +1,14 @@
 const TARGET_SAMPLE_RATE = 16000;
-const CHUNK_SIZE = TARGET_SAMPLE_RATE; // 1 second of mono audio
+const CHUNK_SIZE = TARGET_SAMPLE_RATE;
 
 const { downsampleBuffer, formatTimestamp } = window.rendererUtils || {};
 if (typeof downsampleBuffer !== 'function' || typeof formatTimestamp !== 'function') {
   throw new Error('Renderer utilities failed to load.');
 }
+
+const PANE_CONFIG_STORAGE_KEY = 'transcribeRS.panes.v1';
+const PANE_LAYOUT_STORAGE_KEY = 'transcribeRS.layout.v1';
+const DEFAULT_TRANSCRIPT_POSITION = { x: 24, y: 24 };
 
 const modelInput = document.getElementById('modelPath');
 const engineSelect = document.getElementById('engine');
@@ -12,21 +16,32 @@ const languageInput = document.getElementById('language');
 const startButton = document.getElementById('startButton');
 const stopButton = document.getElementById('stopButton');
 const statusLine = document.getElementById('status');
+const paneTemplateSelect = document.getElementById('paneTemplate');
+const addPaneButton = document.getElementById('addPaneButton');
+const customPaneButton = document.getElementById('customPaneButton');
+const paneHint = document.getElementById('paneHint');
+const paneCanvas = document.getElementById('paneCanvas');
 const transcriptContainer = document.getElementById('transcript');
-const notesList = document.getElementById('notes');
-const notesStatus = document.getElementById('notesStatus');
+const transcriptStatus = document.getElementById('transcriptStatus');
+const transcriptPaneElement = paneCanvas.querySelector('[data-pane-id="transcript"]');
 
 let audioContext = null;
 let mediaStream = null;
 let processorNode = null;
 let bufferQueue = [];
 let capturing = false;
-let notesEnabled = false;
+let llmAvailable = false;
+let paneTemplates = [];
+let paneTemplateLookup = new Map();
+let zCounter = 20;
 
-window.electronAPI.onceNotesAvailability((available) => {
-  notesEnabled = available;
-  refreshNotesStatus();
-});
+const paneState = new Map();
+const paneElements = new Map();
+const paneLayout = loadPaneLayout();
+let activePaneConfigs = loadActivePaneConfigs();
+
+initializeTranscriptPane();
+bootstrapTemplates();
 
 window.electronAPI.onStatus((message) => {
   statusLine.textContent = message;
@@ -36,22 +51,32 @@ window.electronAPI.onTranscript((payload) => {
   renderTranscript(payload);
 });
 
-window.electronAPI.onNotes((payload) => {
-  renderNotes(payload);
+window.electronAPI.onPaneUpdate((payload) => {
+  if (!payload || !payload.id) {
+    return;
+  }
+  const normalized = normalizePaneUpdate(payload);
+  paneState.set(normalized.id, normalized);
+  const entry = ensurePaneElement(normalized.id, normalized);
+  renderPane(entry, normalized);
+  ensurePanePosition(normalized.id);
+  refreshPaneHint();
 });
 
-window.electronAPI.onNotesStatus((state) => {
-  switch (state) {
-    case 'generating':
-      notesStatus.textContent = 'Generating notes…';
-      break;
-    case 'error':
-      notesStatus.textContent = 'Note generation error';
-      break;
-    default:
-      refreshNotesStatus();
-      break;
+window.electronAPI.onPaneRemoved((paneId) => {
+  if (!paneId || paneId === 'transcript') {
+    return;
   }
+  paneState.delete(paneId);
+  removePaneElement(paneId);
+  delete paneLayout[paneId];
+  savePaneLayout();
+  refreshPaneHint();
+});
+
+window.electronAPI.oncePaneAvailability((available) => {
+  llmAvailable = Boolean(available);
+  refreshPaneHint();
 });
 
 startButton.addEventListener('click', async () => {
@@ -81,18 +106,22 @@ startButton.addEventListener('click', async () => {
       return;
     }
 
-    notesEnabled = Boolean(response.notesEnabled);
+    if (typeof response.llmAvailable === 'boolean') {
+      llmAvailable = response.llmAvailable;
+    }
+
     await startCapture();
     capturing = true;
     startButton.disabled = true;
     stopButton.disabled = false;
-    refreshNotesStatus();
+    refreshPaneHint();
     statusLine.textContent = 'Listening…';
+    transcriptStatus.textContent = 'Streaming transcript…';
   } catch (error) {
     console.error(error);
     statusLine.textContent = `Start failed: ${error.message}`;
     startButton.disabled = false;
-    refreshNotesStatus();
+    refreshPaneHint();
   }
 });
 
@@ -107,56 +136,161 @@ stopButton.addEventListener('click', async () => {
   } finally {
     capturing = false;
     startButton.disabled = false;
-    refreshNotesStatus();
+    refreshPaneHint();
     statusLine.textContent = 'Capture stopped.';
+    transcriptStatus.textContent = 'Capture paused.';
   }
 });
 
-async function startCapture() {
-  if (audioContext) {
+addPaneButton.addEventListener('click', () => {
+  const templateId = paneTemplateSelect.value;
+  if (!templateId) {
+    statusLine.textContent = 'Select a pane template to add.';
+    return;
+  }
+  addPaneFromTemplate(templateId);
+});
+
+customPaneButton.addEventListener('click', () => {
+  createCustomPane();
+});
+
+paneCanvas.addEventListener('click', (event) => {
+  const pane = event.target.closest('.floating-pane');
+  if (!pane) {
+    return;
+  }
+  elevatePane(pane);
+});
+
+window.addEventListener('resize', () => {
+  for (const paneId of Object.keys(paneLayout)) {
+    updatePanePosition(paneId, paneLayout[paneId]?.x, paneLayout[paneId]?.y, {
+      clamp: true,
+      persist: true,
+    });
+  }
+});
+
+function initializeTranscriptPane() {
+  if (!paneLayout.transcript) {
+    paneLayout.transcript = { ...DEFAULT_TRANSCRIPT_POSITION };
+  }
+  const entry = {
+    element: transcriptPaneElement,
+    statusEl: transcriptStatus,
+    contentEl: transcriptContainer,
+    titleEl: transcriptPaneElement.querySelector('.pane-title'),
+    actions: {},
+  };
+  paneElements.set('transcript', entry);
+  makePaneDraggable(transcriptPaneElement, 'transcript');
+  ensurePanePosition('transcript');
+  refreshPaneHint();
+}
+
+async function bootstrapTemplates() {
+  try {
+    const templates = await window.electronAPI.getPaneTemplates();
+    paneTemplates = Array.isArray(templates) ? templates : [];
+  } catch (error) {
+    console.warn('Failed to load pane templates', error);
+    paneTemplates = [];
+  }
+
+  paneTemplateLookup = new Map(
+    paneTemplates.map((template, index) => [
+      template.templateId || `template-${index}`,
+      template,
+    ])
+  );
+
+  populateTemplateSelect();
+
+  if (!Array.isArray(activePaneConfigs) || !activePaneConfigs.length) {
+    const noteTemplate = paneTemplates.find((tpl) => tpl.templateId === 'note-taker') || paneTemplates[0];
+    if (noteTemplate) {
+      const config = createPaneConfigFromTemplate(noteTemplate);
+      activePaneConfigs = [config];
+      ensurePanePosition(config.id);
+      createPanePlaceholder(config);
+    }
+  } else {
+    for (const pane of activePaneConfigs) {
+      ensurePanePosition(pane.id);
+      createPanePlaceholder(pane);
+    }
+  }
+
+  syncPaneConfigs();
+  refreshPaneHint();
+}
+
+function populateTemplateSelect() {
+  paneTemplateSelect.innerHTML = '';
+  if (!paneTemplates.length) {
+    const option = document.createElement('option');
+    option.textContent = 'No templates available';
+    option.disabled = true;
+    paneTemplateSelect.appendChild(option);
     return;
   }
 
-  const stream = await navigator.mediaDevices.getUserMedia({
-    audio: {
-      channelCount: 1,
-      echoCancellation: true,
-      noiseSuppression: true,
-      autoGainControl: false,
-    },
-    video: false,
-  });
-
-  const context = new AudioContext();
-  if (context.state === 'suspended') {
-    await context.resume();
+  for (const template of paneTemplates) {
+    const option = document.createElement('option');
+    option.value = template.templateId || template.title;
+    option.textContent = template.title || template.templateId || 'Pane';
+    paneTemplateSelect.appendChild(option);
   }
-  const source = context.createMediaStreamSource(stream);
-  const processor = context.createScriptProcessor(4096, 1, 1);
-  processor.onaudioprocess = (event) => {
-    const input = event.inputBuffer.getChannelData(0);
-    const downsampled = downsampleBuffer(input, context.sampleRate, TARGET_SAMPLE_RATE);
-    if (!downsampled || !downsampled.length) {
-      return;
-    }
+}
 
-    for (let i = 0; i < downsampled.length; i += 1) {
-      bufferQueue.push(downsampled[i]);
-    }
+function startCapture() {
+  if (audioContext) {
+    return Promise.resolve();
+  }
 
-    while (bufferQueue.length >= CHUNK_SIZE) {
-      const chunk = bufferQueue.splice(0, CHUNK_SIZE);
-      window.electronAPI.sendAudioChunk(Float32Array.from(chunk));
-    }
-  };
+  return navigator.mediaDevices
+    .getUserMedia({
+      audio: {
+        channelCount: 1,
+        echoCancellation: true,
+        noiseSuppression: true,
+        autoGainControl: false,
+      },
+      video: false,
+    })
+    .then(async (stream) => {
+      const context = new AudioContext();
+      if (context.state === 'suspended') {
+        await context.resume();
+      }
+      const source = context.createMediaStreamSource(stream);
+      const processor = context.createScriptProcessor(4096, 1, 1);
+      processor.onaudioprocess = (event) => {
+        const input = event.inputBuffer.getChannelData(0);
+        const downsampled = downsampleBuffer(input, context.sampleRate, TARGET_SAMPLE_RATE);
+        if (!downsampled || !downsampled.length) {
+          return;
+        }
 
-  source.connect(processor);
-  processor.connect(context.destination);
+        for (let i = 0; i < downsampled.length; i += 1) {
+          bufferQueue.push(downsampled[i]);
+        }
 
-  audioContext = context;
-  mediaStream = stream;
-  processorNode = processor;
-  bufferQueue = [];
+        while (bufferQueue.length >= CHUNK_SIZE) {
+          const chunk = bufferQueue.splice(0, CHUNK_SIZE);
+          window.electronAPI.sendAudioChunk(Float32Array.from(chunk));
+        }
+      };
+
+      source.connect(processor);
+      processor.connect(context.destination);
+
+      audioContext = context;
+      mediaStream = stream;
+      processorNode = processor;
+      bufferQueue = [];
+    });
 }
 
 async function stopCapture() {
@@ -192,58 +326,661 @@ function renderTranscript(payload) {
   transcriptContainer.innerHTML = '';
 
   if (!segments.length) {
-    transcriptContainer.classList.add('placeholder');
-    transcriptContainer.textContent = 'No audio yet.';
+    transcriptStatus.textContent = capturing ? 'Listening for audio…' : 'No audio yet.';
+    const placeholder = document.createElement('div');
+    placeholder.className = 'pane-placeholder';
+    placeholder.textContent = 'Start capture to stream the transcript.';
+    transcriptContainer.appendChild(placeholder);
     return;
   }
 
-  transcriptContainer.classList.remove('placeholder');
+  transcriptStatus.textContent = capturing ? 'Streaming transcript…' : 'Transcript paused.';
 
-  segments.forEach((segment) => {
+  const recentSegments = segments.slice(-60);
+  for (const segment of recentSegments) {
     const row = document.createElement('div');
-    row.className = 'segment';
+    row.className = 'transcript-segment';
 
     const ts = document.createElement('span');
-    ts.className = 'timestamp';
+    ts.className = 'transcript-timestamp';
     ts.textContent = formatTimestamp(segment.start, segment.end);
 
     const text = document.createElement('span');
-    text.className = 'segment-text';
+    text.className = 'transcript-text';
     text.textContent = (segment.text || '').trim();
 
     row.appendChild(ts);
     row.appendChild(text);
     transcriptContainer.appendChild(row);
-  });
+  }
 
   transcriptContainer.scrollTop = transcriptContainer.scrollHeight;
 }
 
-function renderNotes(payload) {
-  const bullets = Array.isArray(payload?.bullets) ? payload.bullets : [];
-  notesList.innerHTML = '';
+function normalizePaneUpdate(payload) {
+  return {
+    id: String(payload.id),
+    title: payload.title ? String(payload.title) : 'AI Pane',
+    variant: payload.variant === 'text' ? 'text' : 'list',
+    status: String(payload.status || 'idle'),
+    items: Array.isArray(payload.items) ? payload.items.map((item) => String(item)) : [],
+    text: typeof payload.text === 'string' ? payload.text : '',
+    error: typeof payload.error === 'string' ? payload.error : '',
+    raw: typeof payload.raw === 'string' ? payload.raw : '',
+    structured: Array.isArray(payload.structured) ? payload.structured : [],
+    lastUpdated: Number.isFinite(payload.lastUpdated) ? payload.lastUpdated : null,
+    allowPromptEdit: payload.allowPromptEdit !== false,
+    model: typeof payload.model === 'string' ? payload.model : undefined,
+  };
+}
 
-  if (!bullets.length) {
-    const empty = document.createElement('div');
-    empty.className = 'placeholder';
-    empty.textContent = notesEnabled
-      ? 'Notes will appear once we capture speech.'
-      : 'Provide an OPENAI_API_KEY in .env to enable notes.';
-    notesList.appendChild(empty);
+function ensurePaneElement(paneId, paneUpdate) {
+  if (paneElements.has(paneId)) {
+    return paneElements.get(paneId);
+  }
+
+  const element = document.createElement('article');
+  element.className = 'floating-pane';
+  element.dataset.paneId = paneId;
+
+  const header = document.createElement('div');
+  header.className = 'pane-header';
+
+  const title = document.createElement('div');
+  title.className = 'pane-title';
+  header.appendChild(title);
+
+  const actions = document.createElement('div');
+  actions.className = 'pane-actions';
+
+  const refreshButton = document.createElement('button');
+  refreshButton.className = 'pane-action';
+  refreshButton.title = 'Refresh now';
+  refreshButton.dataset.action = 'refresh';
+  refreshButton.textContent = '↻';
+
+  const editButton = document.createElement('button');
+  editButton.className = 'pane-action';
+  editButton.title = 'Edit pane';
+  editButton.dataset.action = 'edit';
+  editButton.textContent = '✎';
+
+  const closeButton = document.createElement('button');
+  closeButton.className = 'pane-action';
+  closeButton.title = 'Close pane';
+  closeButton.dataset.action = 'close';
+  closeButton.textContent = '✕';
+
+  actions.append(refreshButton, editButton, closeButton);
+  header.appendChild(actions);
+
+  const body = document.createElement('div');
+  body.className = 'pane-body';
+
+  const status = document.createElement('div');
+  status.className = 'pane-status';
+  body.appendChild(status);
+
+  const content = document.createElement('div');
+  content.className = 'pane-content';
+  body.appendChild(content);
+
+  element.appendChild(header);
+  element.appendChild(body);
+  paneCanvas.appendChild(element);
+
+  const entry = {
+    element,
+    header,
+    titleEl: title,
+    statusEl: status,
+    contentEl: content,
+    actions: {
+      refreshButton,
+      editButton,
+      closeButton,
+    },
+  };
+
+  paneElements.set(paneId, entry);
+  attachPaneActionHandlers(entry, paneId);
+  makePaneDraggable(element, paneId);
+  ensurePanePosition(paneId);
+  if (paneUpdate) {
+    renderPane(entry, paneUpdate);
+  }
+  return entry;
+}
+
+function renderPane(entry, state) {
+  const config = getPaneConfig(state.id);
+  entry.titleEl.textContent = state.title;
+
+  const statusText = resolvePaneStatus(state);
+  entry.statusEl.textContent = statusText.text;
+  entry.statusEl.classList.toggle('error', statusText.isError);
+
+  if (entry.actions?.refreshButton) {
+    entry.actions.refreshButton.disabled = !llmAvailable || state.status === 'generating';
+  }
+  if (entry.actions?.editButton) {
+    const editable = (config?.allowPromptEdit ?? state.allowPromptEdit) !== false;
+    entry.actions.editButton.disabled = !editable;
+  }
+
+  entry.contentEl.innerHTML = '';
+  if (state.variant === 'text') {
+    if (state.text.trim()) {
+      const block = document.createElement('div');
+      block.className = 'pane-text-block';
+      block.textContent = state.text.trim();
+      entry.contentEl.appendChild(block);
+    } else {
+      entry.contentEl.appendChild(createPanePlaceholder(state));
+    }
+  } else {
+    if (Array.isArray(state.items) && state.items.length) {
+      const list = document.createElement('ul');
+      list.className = 'pane-list';
+      state.items.forEach((item) => {
+        const li = document.createElement('li');
+        li.textContent = item;
+        list.appendChild(li);
+      });
+      entry.contentEl.appendChild(list);
+    } else {
+      entry.contentEl.appendChild(createPanePlaceholder(state));
+    }
+  }
+}
+
+function createPanePlaceholder(state) {
+  const placeholder = document.createElement('div');
+  placeholder.className = 'pane-placeholder';
+  if (state.status === 'llm-unavailable') {
+    placeholder.textContent = 'Provide an OPENAI_API_KEY to activate this pane.';
+  } else if (!capturing) {
+    placeholder.textContent = 'Start capture to feed this pane with live transcript.';
+  } else if (state.status === 'generating') {
+    placeholder.textContent = 'Synthesizing…';
+  } else {
+    placeholder.textContent = 'Listening… awaiting new insight.';
+  }
+  return placeholder;
+}
+
+function resolvePaneStatus(state) {
+  const result = { text: '', isError: false };
+  switch (state.status) {
+    case 'llm-unavailable':
+      result.text = 'AI disabled — add OPENAI_API_KEY to stream updates.';
+      break;
+    case 'waiting':
+      result.text = capturing ? 'Waiting for fresh transcript…' : 'Idle until capture starts.';
+      break;
+    case 'generating':
+      result.text = 'Synthesizing update…';
+      break;
+    case 'error':
+      result.text = state.error ? `Error: ${state.error}` : 'Pane error';
+      result.isError = true;
+      break;
+    case 'ready':
+      result.text = state.lastUpdated ? `Updated ${formatRelativeTime(state.lastUpdated)}` : 'Up to date.';
+      break;
+    default:
+      result.text = 'Idle.';
+  }
+  return result;
+}
+
+function formatRelativeTime(timestamp) {
+  if (!timestamp) {
+    return 'moments ago';
+  }
+  const delta = Date.now() - timestamp;
+  if (delta < 2000) {
+    return 'just now';
+  }
+  const seconds = Math.floor(delta / 1000);
+  if (seconds < 60) {
+    return `${seconds}s ago`;
+  }
+  const minutes = Math.floor(seconds / 60);
+  if (minutes < 60) {
+    return `${minutes}m ago`;
+  }
+  const hours = Math.floor(minutes / 60);
+  return `${hours}h ago`;
+}
+
+function attachPaneActionHandlers(entry, paneId) {
+  if (entry.actions?.refreshButton) {
+    entry.actions.refreshButton.addEventListener('click', () => {
+      if (!llmAvailable) {
+        statusLine.textContent = 'AI panes require an OPENAI_API_KEY.';
+        return;
+      }
+      window.electronAPI.requestPaneRefresh(paneId);
+    });
+  }
+
+  if (entry.actions?.editButton) {
+    entry.actions.editButton.addEventListener('click', () => {
+      editPane(paneId);
+    });
+  }
+
+  if (entry.actions?.closeButton) {
+    entry.actions.closeButton.addEventListener('click', () => {
+      removePane(paneId);
+    });
+  }
+}
+
+function makePaneDraggable(element, paneId) {
+  const header = element.querySelector('.pane-header');
+  if (!header) {
     return;
   }
 
-  bullets.forEach((bullet) => {
-    const item = document.createElement('li');
-    item.textContent = bullet;
-    notesList.appendChild(item);
-  });
+  const handlePointerDown = (event) => {
+    if (event.button !== 0) {
+      return;
+    }
+    event.preventDefault();
+    elevatePane(element);
+
+    const canvasRect = paneCanvas.getBoundingClientRect();
+    const rect = element.getBoundingClientRect();
+
+    const startX = event.clientX;
+    const startY = event.clientY;
+    const originX = rect.left - canvasRect.left;
+    const originY = rect.top - canvasRect.top;
+    const pointerId = event.pointerId;
+
+    const move = (ev) => {
+      if (ev.pointerId !== pointerId) {
+        return;
+      }
+      const dx = ev.clientX - startX;
+      const dy = ev.clientY - startY;
+      updatePanePosition(paneId, originX + dx, originY + dy, { clamp: true, persist: false });
+    };
+
+    const stop = (ev) => {
+      if (ev.pointerId !== pointerId) {
+        return;
+      }
+      header.removeEventListener('pointermove', move);
+      header.removeEventListener('pointerup', stop);
+      header.removeEventListener('pointercancel', stop);
+      try {
+        header.releasePointerCapture(pointerId);
+      } catch (err) {
+        // ignore
+      }
+      element.classList.remove('dragging');
+      updatePanePosition(paneId, undefined, undefined, { clamp: true, persist: true });
+    };
+
+    try {
+      header.setPointerCapture(pointerId);
+    } catch (err) {
+      // ignore
+    }
+    element.classList.add('dragging');
+    header.addEventListener('pointermove', move);
+    header.addEventListener('pointerup', stop);
+    header.addEventListener('pointercancel', stop);
+  };
+
+  header.addEventListener('pointerdown', handlePointerDown);
 }
 
-function refreshNotesStatus() {
-  if (!notesEnabled) {
-    notesStatus.textContent = 'Notes disabled (missing OPENAI_API_KEY).';
+function updatePanePosition(paneId, nextX, nextY, { clamp = true, persist = false } = {}) {
+  const entry = paneElements.get(paneId);
+  const element = entry?.element || (paneId === 'transcript' ? transcriptPaneElement : null);
+  if (!element) {
     return;
   }
-  notesStatus.textContent = capturing ? 'Notes ready.' : 'Notes idle.';
+
+  const canvasRect = paneCanvas.getBoundingClientRect();
+  const rect = element.getBoundingClientRect();
+
+  let x = typeof nextX === 'number' && Number.isFinite(nextX) ? nextX : paneLayout[paneId]?.x ?? DEFAULT_TRANSCRIPT_POSITION.x;
+  let y = typeof nextY === 'number' && Number.isFinite(nextY) ? nextY : paneLayout[paneId]?.y ?? DEFAULT_TRANSCRIPT_POSITION.y;
+
+  if (clamp) {
+    const maxX = Math.max(16, canvasRect.width - rect.width - 16);
+    const maxY = Math.max(16, canvasRect.height - rect.height - 16);
+    x = Math.min(Math.max(16, x), maxX);
+    y = Math.min(Math.max(16, y), maxY);
+  }
+
+  paneLayout[paneId] = { x, y };
+  element.style.left = `${Math.round(x)}px`;
+  element.style.top = `${Math.round(y)}px`;
+
+  if (persist) {
+    savePaneLayout();
+  }
 }
+
+function ensurePanePosition(paneId) {
+  if (!paneLayout[paneId]) {
+    paneLayout[paneId] = computeInitialPosition(paneId);
+    savePaneLayout();
+  }
+  updatePanePosition(paneId, paneLayout[paneId].x, paneLayout[paneId].y, { clamp: true, persist: false });
+}
+
+function computeInitialPosition(paneId) {
+  if (paneId === 'transcript') {
+    return { ...DEFAULT_TRANSCRIPT_POSITION };
+  }
+  const index = activePaneConfigs.findIndex((pane) => pane.id === paneId);
+  const column = index % 3;
+  const row = Math.floor(index / 3);
+  return {
+    x: 220 + column * 260,
+    y: 60 + row * 240,
+  };
+}
+
+function elevatePane(element) {
+  zCounter += 1;
+  element.style.zIndex = zCounter;
+}
+
+function addPaneFromTemplate(templateId) {
+  const template = paneTemplateLookup.get(templateId);
+  if (!template) {
+    statusLine.textContent = 'Unable to find selected template.';
+    return;
+  }
+  const config = createPaneConfigFromTemplate(template);
+  activePaneConfigs.push(config);
+  ensurePanePosition(config.id);
+  createPanePlaceholder(config);
+  syncPaneConfigs();
+  refreshPaneHint();
+}
+
+function createCustomPane() {
+  const titleInput = window.prompt('Pane title', 'Custom pane');
+  if (titleInput === null) {
+    return;
+  }
+  const modeInput = window.prompt('Display as "list" or "text"?', 'list');
+  if (modeInput === null) {
+    return;
+  }
+  const instructionsInput = window.prompt(
+    'Pane instructions (use {{transcript}} where the live transcript should appear).',
+    'Summarize the discussion and highlight risks.'
+  );
+  if (instructionsInput === null) {
+    return;
+  }
+  const systemInput = window.prompt('Optional system guidance (leave blank for default).', '') || '';
+  const modelInputValue = window.prompt('Optional model (press Enter to keep default).', '') || '';
+
+  const variant = modeInput.trim().toLowerCase() === 'text' ? 'text' : 'list';
+  const config = {
+    id: createPaneId('custom'),
+    title: titleInput.trim() || 'Custom pane',
+    variant,
+    systemPrompt: systemInput.trim() || undefined,
+    promptTemplate: ensureTranscriptPlaceholder(instructionsInput.trim() || 'Analyze the transcript:
+{{transcript}}'),
+    response: variant === 'text' ? { type: 'text' } : { type: 'text_list' },
+    throttleMs: 1600,
+    allowPromptEdit: true,
+    templateId: 'custom',
+  };
+
+  if (modelInputValue.trim()) {
+    config.model = modelInputValue.trim();
+  }
+
+  activePaneConfigs.push(config);
+  ensurePanePosition(config.id);
+  createPanePlaceholder(config);
+  syncPaneConfigs();
+  refreshPaneHint();
+}
+
+function editPane(paneId) {
+  const index = activePaneConfigs.findIndex((pane) => pane.id === paneId);
+  if (index === -1) {
+    return;
+  }
+  const config = activePaneConfigs[index];
+  if (config.allowPromptEdit === false) {
+    statusLine.textContent = 'This pane template does not allow editing.';
+    return;
+  }
+
+  const newTitle = window.prompt('Pane title', config.title || 'AI Pane');
+  if (newTitle === null) {
+    return;
+  }
+  const newInstructions = window.prompt(
+    'Pane instructions (use {{transcript}} placeholder).',
+    config.promptTemplate || ''
+  );
+  if (newInstructions === null) {
+    return;
+  }
+  const newSystem = window.prompt('System guidance (optional).', config.systemPrompt || '') || '';
+  const newModel = window.prompt('Model (optional).', config.model || '') || '';
+
+  config.title = newTitle.trim() || config.title;
+  config.promptTemplate = ensureTranscriptPlaceholder(newInstructions.trim() || config.promptTemplate);
+  config.systemPrompt = newSystem.trim() || undefined;
+  config.model = newModel.trim() || undefined;
+
+  activePaneConfigs[index] = config;
+  syncPaneConfigs();
+  refreshPaneHint();
+}
+
+function removePane(paneId) {
+  const index = activePaneConfigs.findIndex((pane) => pane.id === paneId);
+  if (index === -1) {
+    return;
+  }
+  activePaneConfigs.splice(index, 1);
+  delete paneLayout[paneId];
+  savePaneLayout();
+  syncPaneConfigs();
+  removePaneElement(paneId);
+  paneState.delete(paneId);
+  refreshPaneHint();
+}
+
+function removePaneElement(paneId) {
+  const entry = paneElements.get(paneId);
+  if (!entry) {
+    return;
+  }
+  entry.element.remove();
+  paneElements.delete(paneId);
+}
+
+function syncPaneConfigs() {
+  saveActivePaneConfigs();
+  window.electronAPI.setPaneConfigs(activePaneConfigs);
+}
+
+function createPanePlaceholder(config) {
+  const placeholderState = {
+    id: config.id,
+    title: config.title,
+    variant: config.variant,
+    status: 'waiting',
+    items: [],
+    text: '',
+    allowPromptEdit: config.allowPromptEdit !== false,
+  };
+  paneState.set(config.id, placeholderState);
+  const entry = ensurePaneElement(config.id, placeholderState);
+  renderPane(entry, placeholderState);
+}
+
+function loadActivePaneConfigs() {
+  try {
+    const raw = localStorage.getItem(PANE_CONFIG_STORAGE_KEY);
+    if (!raw) {
+      return [];
+    }
+    const parsed = JSON.parse(raw);
+    if (!Array.isArray(parsed)) {
+      return [];
+    }
+    return parsed
+      .map((entry) => sanitizePaneConfig(entry))
+      .filter((entry) => entry !== null);
+  } catch (error) {
+    console.warn('Failed to load pane configs', error);
+    return [];
+  }
+}
+
+function saveActivePaneConfigs() {
+  try {
+    const payload = activePaneConfigs.map((config) => ({
+      id: config.id,
+      title: config.title,
+      variant: config.variant,
+      systemPrompt: config.systemPrompt,
+      promptTemplate: config.promptTemplate,
+      response: config.response,
+      throttleMs: config.throttleMs,
+      model: config.model,
+      templateId: config.templateId,
+      allowPromptEdit: config.allowPromptEdit !== false,
+      maxSegments: config.maxSegments,
+      maxOutputTokens: config.maxOutputTokens,
+    }));
+    localStorage.setItem(PANE_CONFIG_STORAGE_KEY, JSON.stringify(payload));
+  } catch (error) {
+    console.warn('Failed to save pane configs', error);
+  }
+}
+
+function loadPaneLayout() {
+  try {
+    const raw = localStorage.getItem(PANE_LAYOUT_STORAGE_KEY);
+    if (!raw) {
+      return {};
+    }
+    const parsed = JSON.parse(raw);
+    if (!parsed || typeof parsed !== 'object') {
+      return {};
+    }
+    return parsed;
+  } catch (error) {
+    console.warn('Failed to load pane layout', error);
+    return {};
+  }
+}
+
+function savePaneLayout() {
+  try {
+    localStorage.setItem(PANE_LAYOUT_STORAGE_KEY, JSON.stringify(paneLayout));
+  } catch (error) {
+    console.warn('Failed to save pane layout', error);
+  }
+}
+
+function sanitizePaneConfig(entry) {
+  if (!entry || typeof entry !== 'object') {
+    return null;
+  }
+  if (!entry.id) {
+    return null;
+  }
+  return {
+    id: String(entry.id),
+    title: entry.title ? String(entry.title) : 'AI Pane',
+    variant: entry.variant === 'text' ? 'text' : 'list',
+    systemPrompt: entry.systemPrompt ? String(entry.systemPrompt) : undefined,
+    promptTemplate: ensureTranscriptPlaceholder(
+      entry.promptTemplate ? String(entry.promptTemplate) : 'Live transcript:
+{{transcript}}'
+    ),
+    response: typeof entry.response === 'object' ? entry.response : undefined,
+    throttleMs: Number.isFinite(entry.throttleMs) ? entry.throttleMs : 1600,
+    model: entry.model ? String(entry.model) : undefined,
+    templateId: entry.templateId ? String(entry.templateId) : undefined,
+    allowPromptEdit: entry.allowPromptEdit !== false,
+    maxSegments: Number.isFinite(entry.maxSegments) ? entry.maxSegments : undefined,
+    maxOutputTokens: Number.isFinite(entry.maxOutputTokens) ? entry.maxOutputTokens : undefined,
+  };
+}
+
+function createPaneConfigFromTemplate(template) {
+  const id = createPaneId(template.templateId || 'pane');
+  return {
+    id,
+    title: template.title || 'AI Pane',
+    variant: template.variant === 'text' ? 'text' : 'list',
+    systemPrompt: template.systemPrompt || undefined,
+    promptTemplate: ensureTranscriptPlaceholder(template.promptTemplate || 'Live transcript:
+{{transcript}}'),
+    response: template.response,
+    throttleMs: Number.isFinite(template.throttleMs) ? template.throttleMs : 1600,
+    model: template.model || undefined,
+    templateId: template.templateId,
+    allowPromptEdit: template.allowPromptEdit !== false,
+    maxSegments: Number.isFinite(template.maxSegments) ? template.maxSegments : undefined,
+    maxOutputTokens: Number.isFinite(template.maxOutputTokens) ? template.maxOutputTokens : undefined,
+  };
+}
+
+function ensureTranscriptPlaceholder(promptTemplate) {
+  if (!promptTemplate || typeof promptTemplate !== 'string') {
+    return 'Live transcript:
+{{transcript}}';
+  }
+  if (promptTemplate.includes('{{transcript}}')) {
+    return promptTemplate;
+  }
+  return `${promptTemplate}
+
+Transcript:
+{{transcript}}`;
+}
+
+function createPaneId(prefix) {
+  const rand = Math.random().toString(36).slice(2, 8);
+  return `${prefix}-${Date.now().toString(36)}-${rand}`;
+}
+
+function getPaneConfig(paneId) {
+  return activePaneConfigs.find((pane) => pane.id === paneId) || null;
+}
+
+function refreshPaneHint() {
+  if (!paneTemplates.length) {
+    paneHint.textContent = 'Loading pane templates…';
+    return;
+  }
+  if (!activePaneConfigs.length) {
+    paneHint.textContent = llmAvailable
+      ? 'Add a pane to start generating insights.'
+      : 'Add an OPENAI_API_KEY to enable AI panes.';
+    return;
+  }
+  if (!llmAvailable) {
+    paneHint.textContent = 'Configure OPENAI_API_KEY to let panes process the transcript.';
+    return;
+  }
+  paneHint.textContent = capturing
+    ? 'Streaming transcript into your panes.'
+    : 'Start capture to stream updates into panes.';
+}
+


### PR DESCRIPTION
## Summary
- replace the note-only pipeline with a reusable pane manager that streams transcript updates into multiple AI pane definitions
- rebuild the renderer UI into a floating pane workspace with draggable panes, template selection, custom prompt editing, and layout persistence
- document how to configure panes in the README and add tests covering the pane manager

## Testing
- npm test -- --runInBand

------
https://chatgpt.com/codex/tasks/task_e_68d08d9a7cb883218523cb7647fd9652